### PR TITLE
unsquashfs: add code to dump the exact bytes used

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1640,9 +1640,9 @@ void squashfs_stat(char *source)
 
 	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
 		"failed to get time\n");
-	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n",
-		sBlk.s.bytes_used / 1024.0, sBlk.s.bytes_used /
-		(1024.0 * 1024.0));
+	printf("Filesystem size %llu bytes (%.2f Kbytes / %.2f Mbytes)\n",
+		sBlk.s.bytes_used, sBlk.s.bytes_used / 1024.0,
+		sBlk.s.bytes_used / (1024.0 * 1024.0));
 
 	if(sBlk.s.s_major == 4) {
 		printf("Compression %s\n", comp->name);


### PR DESCRIPTION
The option to display the superblock information currently give a
rounded value of the bytes used by the filesystem.
There are use cases in which knowing the exact value is very valuable.
This commit just adds this information.
