### PR TITLE
fix device type handling with extended attributes

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -1117,7 +1117,11 @@ int create_inode(char *pathname, struct inode *i)
 	 	case SQUASHFS_CHRDEV_TYPE:
  		case SQUASHFS_LBLKDEV_TYPE:
 	 	case SQUASHFS_LCHRDEV_TYPE: {
-			int chrdev = i->type == SQUASHFS_CHRDEV_TYPE;
+			int chrdev = 0;
+			if ( i->type == SQUASHFS_CHRDEV_TYPE ||
+					i->type == SQUASHFS_LCHRDEV_TYPE)
+				chrdev = 1;
+
 			TRACE("create_inode: dev, rdev 0x%llx\n", i->data);
 
 			if(root_process) {


### PR DESCRIPTION
If character device files have extended attributes then
unsquashfs will incorrectly create them as block
device files. This patch checks if the file is character
device file in case it has extended attributes.
