### PR TITLE
mksquashfs: Fix segfault when SQUASHFS_TRACE is enabled and no -pf flag

### DIFF
--- a/squashfs-tools/pseudo.c
+++ b/squashfs-tools/pseudo.c
@@ -518,7 +518,8 @@ static void dump_pseudo(struct pseudo *pseudo, char *string)
 
 void dump_pseudos()
 {
-	dump_pseudo(pseudo, NULL);
+    if (pseudo)
+        dump_pseudo(pseudo, NULL);
 }
 #else
 void dump_pseudos()


### PR DESCRIPTION
Segfault happens when attempting to dump pseudo files in SQUASHFS_TRACE
mode after attempting to dereference NULL pseudo pointer.

Signed-off-by: Mohamad Ayyash mkayyash@google.com
